### PR TITLE
Fixes ios and more

### DIFF
--- a/sticker/lib/matrix.py
+++ b/sticker/lib/matrix.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
         url: str
         info: MediaInfo
         id: str
+        msgtype: str
 else:
     MediaInfo = None
     StickerInfo = None

--- a/sticker/lib/util.py
+++ b/sticker/lib/util.py
@@ -74,4 +74,5 @@ def make_sticker(mxc: str, width: int, height: int, size: int,
                 "mimetype": "image/png",
             },
         },
+        "msgtype": "m.sticker",
     }

--- a/sticker/stickerimport.py
+++ b/sticker/stickerimport.py
@@ -138,11 +138,12 @@ async def main(args: argparse.Namespace) -> None:
     if args.list:
         stickers: AllStickers = await client(GetAllStickersRequest(hash=0))
         index = 1
-        width = len(str(stickers.sets))
+        width = len(str(len(stickers.sets)))
         print("Your saved sticker packs:")
         for saved_pack in stickers.sets:
             print(f"{index:>{width}}. {saved_pack.title} "
                   f"(t.me/addstickers/{saved_pack.short_name})")
+            index += 1
     elif args.pack[0]:
         input_packs = []
         for pack_url in args.pack[0]:


### PR DESCRIPTION
* Add missing msgtype = m.sticker
    * On iOS the message is sent twice, with a duplicate event_id.
    * It causes errors on logs, in different places (synapse, mautrix, ...)
    * It required to fix the already existing json or reimport the stickers.
    * The "packs/scalar*" example already include this field, and it works.
* Fix display of packs with sticker-import --list