### PR TITLE
Allow using external index.json and stickerpack

### DIFF
--- a/web/src/index.js
+++ b/web/src/index.js
@@ -22,12 +22,10 @@ import * as frequent from "./frequently-used.js"
 // then ${PACK_BASE_URL}/${packFile} for each packFile in the packs object of the index.json file.
 const PACKS_BASE_URL = "packs"
 
-let INDEX = `${PACKS_BASE_URL}/index.json`;
-let params = new URLSearchParams(document.location.search);
-let REMOTE = false;
+let INDEX = `${PACKS_BASE_URL}/index.json`
+const params = new URLSearchParams(document.location.search)
 if (params.has('config')) {
-	INDEX = params.get("config");
-	REMOTE = true;
+	INDEX = params.get("config")
 }
 // This is updated from packs/index.json
 let HOMESERVER_URL = "https://matrix-client.matrix.org"
@@ -137,8 +135,8 @@ class App extends Component {
 			HOMESERVER_URL = indexData.homeserver_url || HOMESERVER_URL
 			// TODO only load pack metadata when scrolled into view?
 			for (const packFile of indexData.packs) {
-				let packRes;
-				if (REMOTE) {
+				let packRes
+				if (packFile.startsWith("https://") || packFile.startsWith("http://")) {
 					packRes = await fetch(packFile, { cache })
 				} else {
 					packRes = await fetch(`${PACKS_BASE_URL}/${packFile}`, { cache })

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -36,17 +36,12 @@ const makeThumbnailURL = mxc => `${HOMESERVER_URL}/_matrix/media/r0/thumbnail/${
 // This is also used to fix scrolling to sections on Element iOS
 const isMobileSafari = navigator.userAgent.match(/(iPod|iPhone|iPad)/) && navigator.userAgent.match(/AppleWebKit/)
 
-export const parseQuery = str => Object.fromEntries(
-	str.split("&")
-		.map(part => part.split("="))
-		.map(([key, value = ""]) => [key, value]))
-
 const supportedThemes = ["light", "dark", "black"]
 
 class App extends Component {
 	constructor(props) {
 		super(props)
-		this.defaultTheme = parseQuery(location.search.substr(1)).theme
+		this.defaultTheme = params.get("theme")
 		this.state = {
 			packs: [],
 			loading: true,


### PR DESCRIPTION
The idea behind :
* Give a public instance of stickerpicker users can use directly. Users will have to create a github page with an index.json. It is then possible to have a repo `stickerconf` to fork with default stickers.
* Share more easily packs (Why not having a public repo where users can publish their pack, with a preview webpage)

If there is no `config` GET parameter, it does today's behavior (index.json @ /packs/index.json).

The `packs` in the index.json takes the full URL
```
{
  "packs": [
    "https://example1.tld/stickerpicker/web/packs/aaa.json",
    "https://example2.tld/stickerpicker/web/packs/bbb.json",
    "https://example.tld/stickerpicker/web/packs/ccc.json"
  ]
}
```

* Example of conf : https://p1gp1g.github.io/stickertest/
* Example of widget URL : https://p1gp1g.github.io/stickerpicker-dev/web/?config=https://p1gp1g.github.io/stickertest/

Note: json packs and index.json needs to have wildcard CORS