### PR TITLE
Sync frequently used stickers with current available packs

### DIFF
--- a/web/src/frequently-used.js
+++ b/web/src/frequently-used.js
@@ -13,22 +13,80 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-const FREQUENTLY_USED = JSON.parse(window.localStorage.mauFrequentlyUsedStickerIDs || "{}")
+
+const FREQUENTLY_USED_STORAGE_KEY = 'mauFrequentlyUsedStickerIDs'
+const FREQUENTLY_USED_STORAGE_CACHE_KEY = 'mauFrequentlyUsedStickerCache'
+
+let FREQUENTLY_USED = JSON.parse(window.localStorage[FREQUENTLY_USED_STORAGE_KEY] ?? '{}')
 let FREQUENTLY_USED_SORTED = null
 
-export const add = id => {
-	const [count] = FREQUENTLY_USED[id] || [0]
-	FREQUENTLY_USED[id] = [count + 1, Date.now()]
-	window.localStorage.mauFrequentlyUsedStickerIDs = JSON.stringify(FREQUENTLY_USED)
+const sortFrequentlyUsedEntries = (entry1, entry2) => {
+	const [, [count1, date1]] = entry1
+	const [, [count2, date2]] = entry2
+	return count2 === count1 ? date2 - date1 : count2 - count1
+}
+
+export const setFrequentlyUsedStorage = (frequentlyUsed) => {
+	FREQUENTLY_USED = frequentlyUsed ?? {}
+	window.localStorage[FREQUENTLY_USED_STORAGE_KEY] = JSON.stringify(FREQUENTLY_USED)
 	FREQUENTLY_USED_SORTED = null
+}
+
+export const setFrequentlyUsedCacheStorage = (stickers) => {
+	const toPutInCache = stickers.map(sticker => [sticker.id, sticker])
+	window.localStorage[FREQUENTLY_USED_STORAGE_CACHE_KEY] = JSON.stringify(toPutInCache)
+}
+
+export const add = (id) => {
+	let FREQUENTLY_USED_COPY = { ...FREQUENTLY_USED }
+	const [count] = FREQUENTLY_USED_COPY[id] || [0]
+	FREQUENTLY_USED_COPY[id] = [count + 1, Date.now()]
+	setFrequentlyUsedStorage(FREQUENTLY_USED_COPY)
 }
 
 export const get = (limit = 16) => {
 	if (FREQUENTLY_USED_SORTED === null) {
-		FREQUENTLY_USED_SORTED = Object.entries(FREQUENTLY_USED)
-			.sort(([, [count1, date1]], [, [count2, date2]]) =>
-				count2 === count1 ? date2 - date1 : count2 - count1)
+		FREQUENTLY_USED_SORTED = Object.entries(FREQUENTLY_USED || {})
+			.sort(sortFrequentlyUsedEntries)
 			.map(([emoji]) => emoji)
 	}
 	return FREQUENTLY_USED_SORTED.slice(0, limit)
+}
+
+export const getFromCache = () => {
+	return Object.values(JSON.parse(localStorage[FREQUENTLY_USED_STORAGE_CACHE_KEY] ?? '[]'))
+}
+
+export const remove = (id) => {
+	let FREQUENTLY_USED_COPY = { ...FREQUENTLY_USED }
+	if (FREQUENTLY_USED_COPY[id]) {
+		delete FREQUENTLY_USED_COPY[id]
+		setFrequentlyUsedStorage(FREQUENTLY_USED_COPY)
+	}
+}
+
+export const removeMultiple = (ids) => {
+	let FREQUENTLY_USED_COPY = { ...FREQUENTLY_USED }
+	ids.forEach((id) => {
+		delete FREQUENTLY_USED_COPY[id]
+	})
+	setFrequentlyUsedStorage(FREQUENTLY_USED_COPY)
+}
+
+export const removeAll = setFrequentlyUsedStorage
+
+const compareStorageWith = (packs) => {
+	const stickersIDsFromPacks = packs.map((pack) => pack.stickers).flat().map((sticker) => sticker.id)
+	const stickersIDsFromFrequentlyUsedStorage = get()
+
+	const notFound = stickersIDsFromFrequentlyUsedStorage.filter((id) => !stickersIDsFromPacks.includes(id))
+	const found = stickersIDsFromFrequentlyUsedStorage.filter((id) => !notFound.includes(id))
+
+	return { found, notFound }
+}
+
+export const removeNotFoundFromStorage = (packs) => {
+	const { found, notFound } = compareStorageWith(packs)
+	removeMultiple(notFound)
+	return found
 }


### PR DESCRIPTION
Currently, there are two instances where the storage of frequently used stickers gets out of sync with available packs :
- if a JSON file is removed from the `index.json` file
- if any JSON file for a pack is edited

This means stickers in the "Frequently used" list can have out of date metadatas, and sending them from this list or from the pack can lead to a different sent event. This also means, and that's even more confusing, that a sticker can be found in this list, when it is no longer found in any pack.

These changes aim to properly refresh the list of frequently used with the currently available packs, as well as the current metadatas of the available packs, in order to keep them in sync, and make it less confusing to users.

This also adds a button to clear the frequently used list, for people who may need to, since access to the storage is not the simplest thing.