### PR TITLE
Enable searching by pack name

### DIFF
--- a/web/src/index.js
+++ b/web/src/index.js
@@ -109,6 +109,7 @@ class App extends Component {
 		const packsWithFilteredStickers = allPacks.map(pack => ({
 			...pack,
 			stickers: pack.stickers.filter(sticker =>
+				sanitizeString(pack.title).includes(searchTerm) ||
 				sanitizeString(sticker.body).includes(searchTerm) ||
 				sanitizeString(sticker.id).includes(searchTerm)
 			),


### PR DESCRIPTION
Simple one-line change that makes usability much better when coming from Telegram packs