### PR TITLE
Provide a config for a homeserver with animated media support

### DIFF
--- a/packs/README.md
+++ b/packs/README.md
@@ -9,7 +9,8 @@ array. The index.json file should look something like this:
 
 ```json
 {
-  "homeserver_url": "https://example.com",
+  "homeserver_url": "https://example.com", // required
+  "homeserver_animated_url": "https://example.com", // optional : the URL of a webserver which provides a media repo with animated media support
   "packs": [
     "your_telegram_imported_pack.json",
     "another_telegram_imported_pack.json",


### PR DESCRIPTION
This provides a way to display animated media in the widget, by using a homeserver with a media repo which supports them.

It makes it possible to use one homeserver (which doesn't support such a media repo) for most of the thumbnails, and use one with support for the few animated media.

This is an optional config, which defaults to `homeserver_url`.