### PR TITLE
Properly mark as loading on reload

### DIFF
--- a/web/src/index.js
+++ b/web/src/index.js
@@ -148,6 +148,7 @@ class App extends Component {
 		this.setState({
 			packs: defaultState.packs,
 			filtering: defaultState.filtering,
+			loading: true,
 		})
 		this._loadPacks(true)
 	}


### PR DESCRIPTION
Minor change to properly display the spinner when clicking on "Reload" instead of displaying "No packs found"